### PR TITLE
Remove to_dict method from models

### DIFF
--- a/work_at_olist/base/api.py
+++ b/work_at_olist/base/api.py
@@ -54,7 +54,7 @@ def book_update(request, book_id: int, payload: BookIn):
 @router.delete('/books/delete/{book_id}', response=BookOut)
 def book_delete(request, book_id: int):
     book = get_object_or_404(Book, id=book_id)
-    data = book.to_dict()
+    data = BookOut.from_orm(book).dict()
     book.delete()
 
     return data

--- a/work_at_olist/base/models.py
+++ b/work_at_olist/base/models.py
@@ -7,12 +7,6 @@ class Author(models.Model):
     def __str__(self):
         return self.name
 
-    def to_dict(self):
-        return {
-            "id": self.pk,
-            "name": self.name
-        }
-
 
 class Book(models.Model):
     name = models.CharField(max_length=64)
@@ -25,12 +19,3 @@ class Book(models.Model):
 
     def get_absolute_url(self):
         return f'/api/books/{self.pk}'
-
-    def to_dict(self):
-        return {
-            'id': self.pk,
-            'name': self.name,
-            'edition': self.edition,
-            'publication_year': self.publication_year,
-            'authors': [author.pk for author in self.authors.all()]
-        }

--- a/work_at_olist/base/tests/test_authors_page.py
+++ b/work_at_olist/base/tests/test_authors_page.py
@@ -4,6 +4,7 @@ import pytest
 from http import HTTPStatus
 
 from work_at_olist.base.models import Author
+from work_at_olist.base.schemas import AuthorOut
 from work_at_olist.django_assertions import assert_contains, assert_not_contains
 
 
@@ -49,7 +50,8 @@ def test_authors_present_in_authors_page(resp_authors_page, authors):
     considers that the user is accessing the first page.
     """
     for author in authors[:10]:
-        assert_contains(resp_authors_page, json.dumps(author.to_dict()))
+        author_out = AuthorOut.from_orm(author)
+        assert_contains(resp_authors_page, json.dumps(author_out.dict()))
 
 
 def test_correct_authors_shown_page_2(resp_authors_page_2, authors):
@@ -59,9 +61,11 @@ def test_correct_authors_shown_page_2(resp_authors_page_2, authors):
     - authors from 10 to 19 are shown in page 2.
     """
     for author in authors[:10]:
-        assert_not_contains(resp_authors_page_2, json.dumps(author.to_dict()))
+        author_out = AuthorOut.from_orm(author)
+        assert_not_contains(resp_authors_page_2, json.dumps(author_out.dict()))
     for author in authors[10:20]:
-        assert_contains(resp_authors_page_2, json.dumps(author.to_dict()))
+        author_out = AuthorOut.from_orm(author)
+        assert_contains(resp_authors_page_2, json.dumps(author_out.dict()))
 
 
 def test_filter_by_name(client, authors):
@@ -70,5 +74,6 @@ def test_filter_by_name(client, authors):
     when filtering by name.
     """
     author = Author.objects.get(name='Author 5')
+    author_out = AuthorOut.from_orm(author)
     resp = client.get('/api/authors', {'name': author.name})
-    assert json.loads(resp.content)['items'] == [author.to_dict()]
+    assert json.loads(resp.content)['items'] == [author_out.dict()]

--- a/work_at_olist/base/tests/test_book_creation.py
+++ b/work_at_olist/base/tests/test_book_creation.py
@@ -4,6 +4,7 @@ import pytest
 from http import HTTPStatus
 
 from work_at_olist.base.models import Book
+from work_at_olist.base.schemas import BookOut
 
 
 @pytest.fixture
@@ -40,7 +41,8 @@ def test_book_returned_after_created(resp_book_creation):
     Certifies the book is returned after its creation.
     """
     book = Book.objects.first()
-    assert json.loads(resp_book_creation.content) == book.to_dict()
+    book_out = BookOut.from_orm(book)
+    assert json.loads(resp_book_creation.content) == book_out.dict()
 
 
 def test_book_location_informed_after_creation(resp_book_creation):

--- a/work_at_olist/base/tests/test_book_filters.py
+++ b/work_at_olist/base/tests/test_book_filters.py
@@ -1,6 +1,7 @@
 import json
 from http import HTTPStatus
 from work_at_olist.base.models import Author
+from work_at_olist.base.schemas import BookOut
 
 
 def test_book_filter_by_name(client, books):
@@ -8,8 +9,9 @@ def test_book_filter_by_name(client, books):
     Certifies books can be filtered by name.
     """
     book = books[0]
+    book_out = BookOut.from_orm(book)
     resp = client.get('/api/books', {'name': book.name})
-    assert json.loads(resp.content)['items'] == [book.to_dict()]
+    assert json.loads(resp.content)['items'] == [book_out.dict()]
 
 
 def test_book_filter_by_edition(client, books):
@@ -22,8 +24,10 @@ def test_book_filter_by_edition(client, books):
     book_1.save()
     book_2.edition = 5
     book_2.save()
+    book_out_1 = BookOut.from_orm(book_1)
+    book_out_2 = BookOut.from_orm(book_2)
     resp = client.get('/api/books', {'edition': 5})
-    assert json.loads(resp.content)['items'] == [book_1.to_dict(), book_2.to_dict()]
+    assert json.loads(resp.content)['items'] == [book_out_1.dict(), book_out_2.dict()]
 
 
 def test_book_filter_by_authors_id(client, books):
@@ -39,8 +43,10 @@ def test_book_filter_by_authors_id(client, books):
     a0 = Author.objects.filter(id=book_0.authors.first().pk).first()
     a1 = Author.objects.filter(id=book_1.authors.first().pk).first()
     book_1.authors.add(a0)
+    book_out_0 = BookOut.from_orm(book_0)
+    book_out_1 = BookOut.from_orm(book_1)
     resp = client.get('/api/books', {'authors': [a0.pk, a1.pk]})
-    assert json.loads(resp.content)['items'] == [book_0.to_dict(), book_1.to_dict()]
+    assert json.loads(resp.content)['items'] == [book_out_0.dict(), book_out_1.dict()]
 
 
 def test_book_filter_by_publication_year(client, books):
@@ -50,8 +56,9 @@ def test_book_filter_by_publication_year(client, books):
     book = books[0]
     book.publication_year = 2010
     book.save()
+    book_out = BookOut.from_orm(book)
     resp = client.get('/api/books', {'publication_year': 2010})
-    assert json.loads(resp.content)['items'] == [book.to_dict()]
+    assert json.loads(resp.content)['items'] == [book_out.dict()]
 
 
 def test_error_invalid_publication_year(client, books):

--- a/work_at_olist/base/tests/test_book_read.py
+++ b/work_at_olist/base/tests/test_book_read.py
@@ -3,6 +3,8 @@ import json
 import pytest
 from http import HTTPStatus
 
+from work_at_olist.base.schemas import BookOut
+
 
 @pytest.fixture
 def resp_book_read_page(client, book):
@@ -26,7 +28,8 @@ def test_book_is_present_on_page(resp_book_read_page, book):
     """
     Certifies that the book is shown on read page.
     """
-    assert json.loads(resp_book_read_page.content) == book.to_dict()
+    book_out = BookOut.from_orm(book)
+    assert json.loads(resp_book_read_page.content) == book_out.dict()
 
 
 def test_book_not_found_incorrect_id(client, db):

--- a/work_at_olist/base/tests/test_book_update.py
+++ b/work_at_olist/base/tests/test_book_update.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from http import HTTPStatus
 from work_at_olist.base.models import Book
+from work_at_olist.base.schemas import BookOut
 
 
 @pytest.fixture
@@ -49,7 +50,8 @@ def test_book_returned_after_update(resp_book_update, book_to_update):
     Certifies the book is returned after updated.
     """
     book = Book.objects.get(id=book_to_update.pk)
-    assert json.loads(resp_book_update.content) == book.to_dict()
+    book_out = BookOut.from_orm(book)
+    assert json.loads(resp_book_update.content) == book_out.dict()
 
 
 def test_book_not_found(client, author):

--- a/work_at_olist/base/tests/test_books_page.py
+++ b/work_at_olist/base/tests/test_books_page.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 import pytest
 
+from work_at_olist.base.schemas import BookOut
 from work_at_olist.django_assertions import assert_contains, assert_not_contains
 
 
@@ -36,7 +37,8 @@ def test_books_present_books_page(resp_books_page, books):
     Certifies that the books are present in books page.
     """
     for book in books:
-        assert_contains(resp_books_page, json.dumps(book.to_dict()))
+        book_out = BookOut.from_orm(book)
+        assert_contains(resp_books_page, json.dumps(book_out.dict()))
 
 
 def test_correct_books_shown_page_2(resp_books_page_2, books):
@@ -45,9 +47,11 @@ def test_correct_books_shown_page_2(resp_books_page_2, books):
     shown in page 2.
     """
     for book in books[3:6]:
-        assert_contains(resp_books_page_2, json.dumps(book.to_dict()))
+        book_out = BookOut.from_orm(book)
+        assert_contains(resp_books_page_2, json.dumps(book_out.dict()))
     for book in books[0:3]:
-        assert_not_contains(resp_books_page_2, json.dumps(book.to_dict()))
+        book_out = BookOut.from_orm(book)
+        assert_not_contains(resp_books_page_2, json.dumps(book_out.dict()))
 
 
 def test_correct_number_of_pages_and_current_books_page(resp_books_page_2):


### PR DESCRIPTION
- Remove to_dict() from models;
- Adjust tests.

closes #71